### PR TITLE
update dependencies

### DIFF
--- a/simple-stack-example-kotlin-community-sample/build.gradle.kts
+++ b/simple-stack-example-kotlin-community-sample/build.gradle.kts
@@ -9,6 +9,11 @@ plugins {
 android {
     compileSdkVersion(28)
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId = "com.zhuinden.simplestackkotlindaggerexample"
         minSdkVersion(16)
@@ -36,20 +41,20 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.31")
     implementation("com.android.support:appcompat-v7:28.0.0")
     implementation("com.android.support:recyclerview-v7:28.0.0")
-    implementation("com.squareup.okhttp3:okhttp:3.10.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:3.10.0")
-    implementation("com.google.dagger:dagger:2.16")
+    implementation("com.squareup.okhttp3:okhttp:3.14.1")
+    implementation("com.squareup.okhttp3:logging-interceptor:3.14.1")
+    implementation("com.google.dagger:dagger:2.22.1")
     implementation("com.android.support:support-v4:28.0.0")
-    kapt("com.google.dagger:dagger-compiler:2.16")
+    kapt("com.google.dagger:dagger-compiler:2.22.1")
     implementation(project(":simple-stack"))
 
     implementation("com.squareup.retrofit2:retrofit:2.4.0") {
         // exclude Retrofit’s OkHttp peer-dependency module and define your own module import
         exclude(module = "okhttp")
     }
-    implementation("com.squareup.retrofit2:converter-gson:2.4.0")
-    implementation("io.reactivex.rxjava2:rxandroid:2.0.2")
-    implementation("io.reactivex.rxjava2:rxjava:2.1.16")
+    implementation("com.squareup.retrofit2:converter-gson:2.5.0")
+    implementation("io.reactivex.rxjava2:rxandroid:2.1.0")
+    implementation("io.reactivex.rxjava2:rxjava:2.2.2")
     implementation("com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0")
     implementation("com.android.support:multidex:1.0.3")
     implementation("io.reactivex.rxjava2:rxkotlin:2.2.0")

--- a/simple-stack-example-multistack/build.gradle.kts
+++ b/simple-stack-example-multistack/build.gradle.kts
@@ -41,8 +41,8 @@ dependencies {
 
     annotationProcessor("frankiesardo:auto-parcel:1.0.3")
 
-    annotationProcessor("com.google.dagger:dagger-compiler:2.14.1")
-    implementation("com.google.dagger:dagger:2.14.1")
+    annotationProcessor("com.google.dagger:dagger-compiler:2.22.1")
+    implementation("com.google.dagger:dagger:2.22.1")
     compileOnly("org.glassfish:javax.annotation:10.0-b28")
     implementation("com.android.support:appcompat-v7:28.0.0")
     implementation("com.android.support:recyclerview-v7:28.0.0")

--- a/simple-stack-example-mvp-fragments/build.gradle.kts
+++ b/simple-stack-example-mvp-fragments/build.gradle.kts
@@ -55,18 +55,20 @@ dependencies {
 
     kapt("frankiesardo:auto-parcel:1.0.3")
 
-    kapt("com.google.dagger:dagger-compiler:2.14.1")
-    implementation("com.google.dagger:dagger:2.14.1")
+    kapt("com.google.dagger:dagger-compiler:2.22.1")
+    implementation("com.google.dagger:dagger:2.22.1")
     compileOnly("org.glassfish:javax.annotation:10.0-b28")
 
-    implementation("io.reactivex.rxjava2:rxjava:2.1.10")
-    implementation("io.reactivex.rxjava2:rxandroid:2.0.2")
+    implementation("io.reactivex.rxjava2:rxjava:2.2.2")
+    implementation("io.reactivex.rxjava2:rxandroid:2.1.0")
     implementation("com.jakewharton.rxbinding2:rxbinding:2.1.1")
     implementation("com.jakewharton.rxrelay2:rxrelay:2.0.0")
 
     kapt("dk.ilios:realmfieldnameshelper:1.1.1")
 
-    implementation("com.andkulikov:transitionseverywhere:1.7.0")
+    implementation("com.andkulikov:transitionseverywhere:1.7.0") {
+        exclude(group = "com.android.support", module = "support-v4")
+    }
 
     implementation("org.javatuples:javatuples:1.2")
 }

--- a/simple-stack-example-mvp-fragments/src/main/java/com/zhuinden/simplestackdemoexamplefragments/application/MainView.kt
+++ b/simple-stack-example-mvp-fragments/src/main/java/com/zhuinden/simplestackdemoexamplefragments/application/MainView.kt
@@ -74,7 +74,7 @@ class MainView : DrawerLayout {
 
         buttonAddTask.showIf { key.isFabVisible }
 
-        val fragment = MainActivity[context].supportFragmentManager.findFragmentByTag(key.fragmentTag)
+        val fragment = MainActivity[context].supportFragmentManager.findFragmentByTag(key.fragmentTag)!!
         buttonAddTask.setOnClickListener(key.fabClickListener(fragment))
         if (key.fabDrawableIcon() != 0) {
             buttonAddTask.setImageResource(key.fabDrawableIcon())

--- a/simple-stack-example-mvp-view/build.gradle.kts
+++ b/simple-stack-example-mvp-view/build.gradle.kts
@@ -53,18 +53,20 @@ dependencies {
 
     kapt("frankiesardo:auto-parcel:1.0.3")
 
-    kapt("com.google.dagger:dagger-compiler:2.14.1")
-    implementation("com.google.dagger:dagger:2.14.1")
+    kapt("com.google.dagger:dagger-compiler:2.22.1")
+    implementation("com.google.dagger:dagger:2.22.1")
     compileOnly("org.glassfish:javax.annotation:10.0-b28")
 
-    implementation("io.reactivex.rxjava2:rxjava:2.1.10")
-    implementation("io.reactivex.rxjava2:rxandroid:2.0.2")
+    implementation("io.reactivex.rxjava2:rxjava:2.2.2")
+    implementation("io.reactivex.rxjava2:rxandroid:2.1.0")
     implementation("com.jakewharton.rxbinding2:rxbinding:2.1.1")
     implementation("com.jakewharton.rxrelay2:rxrelay:2.0.0")
 
     kapt("dk.ilios:realmfieldnameshelper:1.1.1")
 
-    implementation("com.andkulikov:transitionseverywhere:1.7.0")
+    implementation("com.andkulikov:transitionseverywhere:1.7.0") {
+        exclude(group = "com.android.support", module = "support-v4")
+    }
 
     implementation("org.javatuples:javatuples:1.2")
     implementation(project(":simple-stack"))

--- a/simple-stack-example-mvvm-fragments/build.gradle.kts
+++ b/simple-stack-example-mvvm-fragments/build.gradle.kts
@@ -58,9 +58,9 @@ dependencies {
     implementation("com.android.support:support-v4:28.0.0")
 
     // live data
-    implementation("android.arch.lifecycle:runtime:1.1.0")
-    implementation("android.arch.lifecycle:extensions:1.1.0")
-    annotationProcessor("android.arch.lifecycle:compiler:1.1.0")
+    implementation("android.arch.lifecycle:runtime:1.1.1")
+    implementation("android.arch.lifecycle:extensions:1.1.1")
+    annotationProcessor("android.arch.lifecycle:compiler:1.1.1")
 
     // useful stuff
     implementation("com.jakewharton:butterknife:8.8.1")
@@ -70,8 +70,8 @@ dependencies {
     implementation("nz.bradcampbell:paperparcel:2.0.4")
     annotationProcessor("nz.bradcampbell:paperparcel-compiler:2.0.4")
     annotationProcessor("com.github.reggar:auto-value-ignore-hash-equals:1.1.4")
-    implementation("com.google.dagger:dagger:2.14.1")
-    annotationProcessor("com.google.dagger:dagger-compiler:2.14.1")
+    implementation("com.google.dagger:dagger:2.22.1")
+    annotationProcessor("com.google.dagger:dagger-compiler:2.22.1")
 
     // Dependencies for local unit tests
     testImplementation("junit:junit:4.12")
@@ -100,7 +100,7 @@ dependencies {
     androidTestImplementation("com.google.dexmaker:dexmaker-mockito:1.2")
 
     // Android Testing Support Library's runner and rules
-    androidTestImplementation("org.assertj:assertj-core:3.9.1")
+    androidTestImplementation("org.assertj:assertj-core:3.11.1")
 
     androidTestImplementation("com.android.support.test:runner:1.0.1") {
         exclude(group = "com.android.support", module = "support-annotations")

--- a/simple-stack-example-mvvm-fragments/src/main/java/com/zhuinden/simplestackexamplemvvm/application/MainActivity.java
+++ b/simple-stack-example-mvvm-fragments/src/main/java/com/zhuinden/simplestackexamplemvvm/application/MainActivity.java
@@ -150,9 +150,9 @@ public class MainActivity
         setCheckedItem(key.navigationViewId());
         supportInvalidateOptionsMenu();
         if(key.isFabVisible()) {
-            fab.setVisibility(View.VISIBLE);
+            fab.show();
         } else {
-            fab.setVisibility(View.GONE);
+            fab.hide();
         }
         Fragment fragment = getSupportFragmentManager().findFragmentByTag(key.getFragmentTag());
         key.setupFab(fragment, fab);

--- a/simple-stack-example-scoping/build.gradle.kts
+++ b/simple-stack-example-scoping/build.gradle.kts
@@ -40,8 +40,8 @@ dependencies {
     implementation("com.android.support:design:28.0.0")
     testImplementation("junit:junit:4.12")
 
-    implementation("io.reactivex.rxjava2:rxjava:2.1.16")
-    implementation("io.reactivex.rxjava2:rxandroid:2.0.2")
+    implementation("io.reactivex.rxjava2:rxjava:2.2.2")
+    implementation("io.reactivex.rxjava2:rxandroid:2.1.0")
     implementation("com.jakewharton.rxbinding2:rxbinding:2.1.1")
     implementation("com.jakewharton.rxrelay2:rxrelay:2.0.0")
 

--- a/simple-stack-example-sharedelement-fragment/build.gradle.kts
+++ b/simple-stack-example-sharedelement-fragment/build.gradle.kts
@@ -39,8 +39,8 @@ dependencies {
     implementation("nz.bradcampbell:paperparcel:2.0.4")
     annotationProcessor("nz.bradcampbell:paperparcel-compiler:2.0.4")
     annotationProcessor("com.github.reggar:auto-value-ignore-hash-equals:1.1.4")
-    implementation("com.google.dagger:dagger:2.14.1")
-    annotationProcessor("com.google.dagger:dagger-compiler:2.14.1")
+    implementation("com.google.dagger:dagger:2.22.1")
+    annotationProcessor("com.google.dagger:dagger-compiler:2.22.1")
 }
 
 configurations.all {


### PR DESCRIPTION
- `com.squareup.okhttp3` from `3.10.0` to `3.14.1`
- `com.google.dagger` from `2.16` to `2.22.1`
- `io.reactivex.rxjava2:rxandroid` from `2.0.2` to `2.1.0`
- `io.reactivex.rxjava2:rxjava` from `2.1.16` to `2.2.2`
- `com.squareup.retrofit2:converter-gson` from `2.4.0` to `2.5.0`
- `android.arch.lifecycle` from `1.1.0` to `1.1.1`
- `org.assertj:assertj-core` from `3.9.1` to `3.11.1`

... also fixed a couple of issues resulting from SDK 28 upgrade.