### PR TITLE
sourceSets to include src/main/kotlin

### DIFF
--- a/simple-stack-example-basic-kotlin/build.gradle.kts
+++ b/simple-stack-example-basic-kotlin/build.gradle.kts
@@ -23,6 +23,9 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
         }
     }
+
+    // See https://kotlinlang.org/docs/reference/using-gradle.html#android-studio
+    sourceSets["main"].java.srcDir("src/main/kotlin")
 }
 
 androidExtensions {

--- a/simple-stack-example-scoping/build.gradle.kts
+++ b/simple-stack-example-scoping/build.gradle.kts
@@ -23,6 +23,9 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
         }
     }
+
+    // See https://kotlinlang.org/docs/reference/using-gradle.html#android-studio
+    sourceSets["main"].java.srcDir("src/main/kotlin")
 }
 
 androidExtensions {


### PR DESCRIPTION
I thought those were not necessary (since command line build works fine) - but, at least with Android Studio 3.4.1 - it won't recognize `src/main/kotlin` as a source code directory, and features (like "Go To Declaration") simply don't work :(