### PR TITLE
[WIP] Fix that lookups did not consider scopes not accessible in latest navigation history

### DIFF
--- a/simple-stack/build.gradle.kts
+++ b/simple-stack/build.gradle.kts
@@ -7,7 +7,7 @@ android {
     compileSdkVersion(28)
 
     defaultConfig {
-        minSdkVersion(1)
+        minSdkVersion(9)
         targetSdkVersion(28)
         versionCode = 1
         versionName = "0.6.0"
@@ -23,6 +23,11 @@ android {
 
     lintOptions {
         isAbortOnError = false
+    }
+
+    compileOptions {
+        this.setSourceCompatibility(JavaVersion.VERSION_1_7)
+        this.setTargetCompatibility(JavaVersion.VERSION_1_7)
     }
 }
 

--- a/simple-stack/src/main/java/com/zhuinden/simplestack/ScopeManager.java
+++ b/simple-stack/src/main/java/com/zhuinden/simplestack/ScopeManager.java
@@ -229,7 +229,6 @@ class ScopeManager {
 
     private static final GlobalServices EMPTY_GLOBAL_SERVICES = GlobalServices.builder().build();
 
-    private final LinkedHashSet<Object> trackedKeys = new LinkedHashSet<>();
     private final ScopeRegistrations scopes = new ScopeRegistrations();
 
     private final IdentityHashMap<Object, Set<String>> scopeEnteredServices = new IdentityHashMap<>();
@@ -398,8 +397,6 @@ class ScopeManager {
         }
         isInitialized = true;
 
-        trackedKeys.addAll(newKeys);
-
         for(Object key : newKeys) {
             if(key instanceof ScopeKey.Child) {
                 ScopeKey.Child child = (ScopeKey.Child) key;
@@ -438,8 +435,6 @@ class ScopeManager {
                 destroyScope(activeScope);
             }
         }
-
-        trackedKeys.retainAll(newState);
     }
 
     void destroyScope(String scopeTag) {

--- a/simple-stack/src/test/java/com/zhuinden/simplestack/ScopeLookupModeTest.java
+++ b/simple-stack/src/test/java/com/zhuinden/simplestack/ScopeLookupModeTest.java
@@ -429,7 +429,7 @@ public class ScopeLookupModeTest {
             @NonNull
             @Override
             public List<String> getParentScopes() {
-                return History.of("parent2");
+                return History.of("parent2", "parent3");
             }
         }
 
@@ -448,9 +448,9 @@ public class ScopeLookupModeTest {
         });
 
         assertThat(backstack.findScopesForKey(new Key1("beep"), ScopeLookupMode.EXPLICIT)).containsExactly("beep", "parent1");
-        assertThat(backstack.findScopesForKey(new Key2("boop"), ScopeLookupMode.EXPLICIT)).containsExactly("boop", "parent2");
+        assertThat(backstack.findScopesForKey(new Key2("boop"), ScopeLookupMode.EXPLICIT)).containsExactly("boop", "parent3", "parent2");
         assertThat(backstack.findScopesForKey(new Key1("beep"), ScopeLookupMode.ALL)).containsExactly("beep", "parent1");
-        assertThat(backstack.findScopesForKey(new Key2("boop"), ScopeLookupMode.ALL)).containsExactly("boop", "parent2", "beep", "parent1");
+        assertThat(backstack.findScopesForKey(new Key2("boop"), ScopeLookupMode.ALL)).containsExactly("boop", "parent3", "parent2", "beep", "parent1");
     }
 
     @Test

--- a/simple-stack/src/test/java/com/zhuinden/simplestack/ScopingTest.java
+++ b/simple-stack/src/test/java/com/zhuinden/simplestack/ScopingTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1828,5 +1829,172 @@ public class ScopingTest {
         assertThat(backstack.lookupService("hello")).isSameAs(helloService);
         assertThat(backstack.lookupService("kappa")).isSameAs(kappaService);
         assertThat(backstack.lookupService("world")).isSameAs(worldService);
+    }
+
+    @Test
+    public void scopeBuiltByNavigationButNotInLatestKeysCanBeFoundByKey() {
+        Backstack backstack = new Backstack();
+
+        final Object helloService = new Object();
+        final Object worldService = new Object();
+        final Object kappaService = new Object();
+
+        backstack.setScopedServices(new ScopedServices() {
+            @Override
+            public void bindServices(@NonNull ServiceBinder serviceBinder) {
+                if("hello".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("hello", helloService);
+                } else if("world".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("world", worldService);
+                } else if("kappa".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("kappa", kappaService);
+                }
+            }
+        });
+
+        class TestKeyWithExplicitParent extends TestKeyWithScope implements ScopeKey.Child {
+            private String[] parentScopes;
+
+            TestKeyWithExplicitParent(String name, String... parentScopes) {
+                super(name);
+                this.parentScopes = parentScopes;
+            }
+
+            protected TestKeyWithExplicitParent(Parcel in) {
+                super(in);
+            }
+
+            @NonNull
+            @Override
+            public List<String> getParentScopes() {
+                return History.from(Arrays.asList(parentScopes));
+            }
+        }
+
+        TestKeyWithScope scopeKey1 = new TestKeyWithScope("hello");
+        TestKeyWithScope scopeKey2 = new TestKeyWithExplicitParent("world", "parent");
+        TestKeyWithScope scopeKey3 = new TestKeyWithScope("kappa");
+
+        backstack.setup(History.of(scopeKey1, scopeKey2));
+
+        final AtomicReference<StateChanger.Callback> callbackRef = new AtomicReference<>();
+
+        backstack.setStateChanger(new StateChanger() {
+            @Override
+            public void handleStateChange(@NonNull StateChange stateChange, @NonNull Callback completionCallback) {
+                callbackRef.set(completionCallback);
+            }
+        });
+
+        callbackRef.get().stateChangeComplete();
+
+        backstack.setHistory(History.of(scopeKey1, scopeKey3), StateChange.REPLACE);
+
+        assertThat(backstack.findScopesForKey(scopeKey1, ScopeLookupMode.ALL)).containsExactly("hello");
+        assertThat(backstack.findScopesForKey(scopeKey2, ScopeLookupMode.ALL)).containsExactly("world", "parent", "hello");
+        assertThat(backstack.findScopesForKey(scopeKey3, ScopeLookupMode.ALL)).containsExactly("kappa", "world", "parent", "hello");
+
+        assertThat(backstack.findScopesForKey(scopeKey1, ScopeLookupMode.EXPLICIT)).containsExactly("hello");
+        assertThat(backstack.findScopesForKey(scopeKey2, ScopeLookupMode.EXPLICIT)).containsExactly("world", "parent");
+        assertThat(backstack.findScopesForKey(scopeKey3, ScopeLookupMode.EXPLICIT)).containsExactly("kappa");
+    }
+
+
+    @Test
+    public void scopeBuiltByNavigationButNotInLatestKeysCanBeFoundFromScope() {
+        Backstack backstack = new Backstack();
+
+        final Object helloService = new Object();
+        final Object worldService = new Object();
+        final Object kappaService = new Object();
+
+        backstack.setScopedServices(new ScopedServices() {
+            @Override
+            public void bindServices(@NonNull ServiceBinder serviceBinder) {
+                if("hello".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("hello", helloService);
+                } else if("world".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("world", worldService);
+                } else if("kappa".equals(serviceBinder.getScopeTag())) {
+                    serviceBinder.addService("kappa", kappaService);
+                }
+            }
+        });
+
+        TestKeyWithScope scopeKey1 = new TestKeyWithScope("hello");
+        TestKeyWithScope scopeKey2 = new TestKeyWithScope("world");
+        TestKeyWithScope scopeKey3 = new TestKeyWithScope("kappa");
+
+        backstack.setup(History.of(scopeKey1, scopeKey2));
+
+        final AtomicReference<StateChanger.Callback> callbackRef = new AtomicReference<>();
+
+        backstack.setStateChanger(new StateChanger() {
+            @Override
+            public void handleStateChange(@NonNull StateChange stateChange, @NonNull Callback completionCallback) {
+                callbackRef.set(completionCallback);
+            }
+        });
+
+        callbackRef.get().stateChangeComplete();
+
+        backstack.setHistory(History.of(scopeKey1, scopeKey3), StateChange.REPLACE);
+
+
+        assertThat(backstack.lookupFromScope("hello", "hello")).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("world", "world")).isSameAs(worldService);
+        assertThat(backstack.lookupFromScope("kappa", "kappa")).isSameAs(kappaService);
+
+        assertThat(backstack.lookupFromScope("hello", "hello", ScopeLookupMode.ALL)).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("world", "world", ScopeLookupMode.ALL)).isSameAs(worldService);
+        assertThat(backstack.lookupFromScope("kappa", "kappa", ScopeLookupMode.ALL)).isSameAs(kappaService);
+
+        assertThat(backstack.lookupFromScope("hello", "hello", ScopeLookupMode.EXPLICIT)).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("world", "world", ScopeLookupMode.EXPLICIT)).isSameAs(worldService);
+        assertThat(backstack.lookupFromScope("kappa", "kappa", ScopeLookupMode.EXPLICIT)).isSameAs(kappaService);
+
+        assertThat(backstack.lookupFromScope("world", "hello")).isSameAs(helloService);
+
+        assertThat(backstack.lookupFromScope("kappa", "hello")).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("kappa", "world")).isSameAs(worldService);
+
+        assertThat(backstack.lookupFromScope("world", "hello", ScopeLookupMode.ALL)).isSameAs(helloService);
+
+        assertThat(backstack.lookupFromScope("kappa", "hello", ScopeLookupMode.ALL)).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("kappa", "world", ScopeLookupMode.ALL)).isSameAs(worldService);
+
+        assertThat(backstack.lookupFromScope("world", "hello", ScopeLookupMode.EXPLICIT)).isSameAs(helloService);
+
+        assertThat(backstack.lookupFromScope("kappa", "hello", ScopeLookupMode.EXPLICIT)).isSameAs(helloService);
+        assertThat(backstack.lookupFromScope("kappa", "world", ScopeLookupMode.EXPLICIT)).isSameAs(worldService);
+
+        //
+
+        assertThat(backstack.canFindFromScope("hello", "hello")).isTrue();
+        assertThat(backstack.canFindFromScope("world", "world")).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "kappa")).isTrue();
+
+        assertThat(backstack.canFindFromScope("hello", "hello", ScopeLookupMode.ALL)).isTrue();
+        assertThat(backstack.canFindFromScope("world", "world", ScopeLookupMode.ALL)).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "kappa", ScopeLookupMode.ALL)).isTrue();
+
+        assertThat(backstack.canFindFromScope("hello", "hello", ScopeLookupMode.EXPLICIT)).isTrue();
+        assertThat(backstack.canFindFromScope("world", "world", ScopeLookupMode.EXPLICIT)).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "kappa", ScopeLookupMode.EXPLICIT)).isTrue();
+
+        assertThat(backstack.canFindFromScope("world", "hello")).isTrue();
+
+        assertThat(backstack.canFindFromScope("kappa", "hello")).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "world")).isTrue();
+
+        assertThat(backstack.canFindFromScope("world", "hello", ScopeLookupMode.ALL)).isTrue();
+
+        assertThat(backstack.canFindFromScope("kappa", "hello", ScopeLookupMode.ALL)).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "world", ScopeLookupMode.ALL)).isTrue();
+
+        assertThat(backstack.canFindFromScope("world", "hello", ScopeLookupMode.EXPLICIT)).isTrue();
+
+        assertThat(backstack.canFindFromScope("kappa", "hello", ScopeLookupMode.EXPLICIT)).isTrue();
+        assertThat(backstack.canFindFromScope("kappa", "world", ScopeLookupMode.EXPLICIT)).isTrue();
     }
 }


### PR DESCRIPTION
Fixes #198

Problem was that the explicit parent scope hierarchies were rebuilt based on the latest navigation keys.

This however means that during a lookup, not all available scopes were considered.

However, this is still a WIP, because any lookup (including `findScopesForKey`) are still based on `latestKeys`, and a failing test + fix should be added for those as well. ALL scopes should be accessed during lookup, not just the ones available from the current latest navigation history.